### PR TITLE
Exclude line comments from block comment pattern

### DIFF
--- a/syntaxes/curry.tmLanguage.json
+++ b/syntaxes/curry.tmLanguage.json
@@ -122,9 +122,6 @@
             "patterns": [
                 {
                     "include": "#block_comment"
-                },
-                {
-                    "include": "#comments"
                 }
             ]
         },


### PR DESCRIPTION
### Fixes #9 

Line comments could cause the grammar to parse the block comment end delimiter `-}` as being part of a line comment, e.g. in

    {- a -- b -}