### PR TITLE
Exclude keywords before function signatures

### DIFF
--- a/syntaxes/curry.tmLanguage.json
+++ b/syntaxes/curry.tmLanguage.json
@@ -370,7 +370,7 @@
             ]
         },
         "function_signature": {
-            "begin": "^(\\s*)(?!--)(?:(\\(\\W\\)|[\\w']+)|[\\(\\[])(?=[\\w',\\s\\[\\]\\(\\)]*((?:::)|∷))",
+            "begin": "^(\\s*)(?!--|where|case|fcase|of|let|in|default|do|mdo|if|then|else|free)(?:(\\(\\W\\)|[\\w']+)|[\\(\\[])(?=[\\w',\\s\\[\\]\\(\\)]*((?:::)|∷))",
             "beginCaptures": {
                 "2": {
                     "name": "entity.name.function.curry"


### PR DESCRIPTION
### Fixes #10 

This applies the syntax highlighting rules slightly more conservatively, to avoid parsing something after a keyword as a function declaration. While this will also reject a few valid declarations (e.g. `where x :: Int ...` or `let x :: Int ...`), these didn't parse correctly anyway (since the `where` or `let` was parsed as a part of the function name) and getting this to work well with Curry's layout rules seems to be less trivial.