### PR TITLE
Add support for language server extensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,45 @@
                     "default": true,
                     "description": "[Recommended] Specifies whether the language server should be used."
                 },
+                "curry.languageServer.extensions": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "description": "Name of the language server extension, for bookkeeping"
+                            },
+                            "extensionPoint": {
+                                "type": "string",
+                                "enum": [
+                                    "hover"
+                                ],
+                                "description": "The language server feature that is to be extended, i.e. where the analysis results will show up"
+                            },
+                            "executable": {
+                                "type": "string",
+                                "description": "The executable to query for analyses"
+                            },
+                            "args": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                },
+                                "default": [],
+                                "description": "The arguments to pass to the executable. May contain placeholders that provide information about the editing context, e.g. {sourceFile} for a path to the edited file or {line} for the current line number. (TODO: Add a comprehensive overview here)"
+                            }
+                        },
+                        "default": {
+                            "name": "Example Extension",
+                            "extensionPoint": "hover",
+                            "executable": "echo",
+                            "args": ["This is an example output: Currently at {sourceFile}:{line}"]
+                        },
+                        "required": ["extensionPoint", "executable"]
+                    },
+                    "description": "External programs that the language server can invoke to provide additional information or analyses e.g. in hovers or other places."
+                },
                 "curry.languageServer.path": {
                     "type": "string",
                     "default": "",

--- a/package.json
+++ b/package.json
@@ -105,6 +105,15 @@
                                 ],
                                 "description": "The language server feature that is to be extended, i.e. where the analysis results will show up"
                             },
+                            "outputFormat": {
+                                "type": "string",
+                                "enum": [
+                                    "plaintext",
+                                    "markdown"
+                                ],
+                                "default": "plaintext",
+                                "description": "The command's output format"
+                            },
                             "executable": {
                                 "type": "string",
                                 "description": "The executable to query for analyses"

--- a/package.json
+++ b/package.json
@@ -144,8 +144,9 @@
                                 "Current Module: {currentModule}",
                                 "Line:           {line}",
                                 "Column:         {column}",
-                                "Expression:     {expression}",
-                                "Type:           {type}"
+                                "Type:           {type}",
+                                "Identifier:     {identifier}",
+                                "Module:         {module}"
                             ]
                         },
                         "required": ["extensionPoint", "executable"]

--- a/package.json
+++ b/package.json
@@ -130,8 +130,18 @@
                         "default": {
                             "name": "Example Extension",
                             "extensionPoint": "hover",
-                            "executable": "echo",
-                            "args": ["This is an example output: Currently at {sourceFile}:{line}"]
+                            "executable": "printf",
+                            "args": [
+                                "%s\n",
+                                "This is an example output:",
+                                "Current File:   {currentFile}",
+                                "Current URI:    {currentUri}",
+                                "Current Module: {currentModule}",
+                                "Line:           {line}",
+                                "Column:         {column}",
+                                "Expression:     {expression}",
+                                "Type:           {type}"
+                            ]
                         },
                         "required": ["extensionPoint", "executable"]
                     },

--- a/package.json
+++ b/package.json
@@ -114,6 +114,11 @@
                                 "default": "plaintext",
                                 "description": "The command's output format"
                             },
+                            "showOutputOnError": {
+                                "type": "boolean",
+                                "default": false,
+                                "description": "Whether to display the standard error if the exit code is 0 (instead of simply not displaying the hover)"
+                            },
                             "executable": {
                                 "type": "string",
                                 "description": "The executable to query for analyses"


### PR DESCRIPTION
Sibling PR to:

- https://github.com/fwcd/curry-language-server/pull/77

This adds support for language server extensions, e.g. for integrating custom analyses that show up in hovers.